### PR TITLE
Add src/setupProxy.js for development purposes

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,6 @@
   "name": "clients",
   "version": "0.1.0",
   "private": true,
-  "type": "module",
   "dependencies": {
     "@babel/eslint-parser": "^7.22.5",
     "@reduxjs/toolkit": "^1.9.3",

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -1,0 +1,14 @@
+const { createProxyMiddleware } = require("http-proxy-middleware");
+
+const onError = (err, req, resp, target) => {
+  console.log(`${err.message}`);
+};
+module.exports = function (app) {
+  app.use(
+    "/api",
+    createProxyMiddleware({
+      target: "http://localhost:4000",
+      changeOrigin: true,
+    })
+  );
+};


### PR DESCRIPTION
Add src/setupProxy.js for development purposes
Remove 'type':'module' from client/package.json because it crashes setup procedure in react

setupProxy.js proxies all requests to api in dev mode, so now we can query api via http://localhost:3000/api